### PR TITLE
Fix #21 - MongoDB port mapping on docker-compose

### DIFF
--- a/backend/docker-compose.yml.dist
+++ b/backend/docker-compose.yml.dist
@@ -21,7 +21,5 @@ services:
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_USERNAME}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD}
-    ports:
-      - "27017:27017"
     volumes:
       - ./data/db:/data/db


### PR DESCRIPTION
Fixed [issue 21](https://github.com/ActxLeToucan/CharlySheet/issues/21) on mongodb useless port mapping.